### PR TITLE
Create index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export default IntersectionObserver;


### PR DESCRIPTION
informs typescript that the default export is simply the global IntersectionObserver class